### PR TITLE
build(gradle): fix git hooks installation on Windows

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
 import org.apache.commons.io.FileUtils
+import org.gradle.internal.os.OperatingSystem
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
+import java.nio.file.Files
 
 plugins {
     kotlin("plugin.serialization") apply false
@@ -39,6 +41,10 @@ fun installGitHooks() {
     val source = File(project.rootProject.rootDir, ".git-hooks")
     if (target.canonicalFile == source) return
     target.deleteRecursively()
-    FileUtils.copyDirectory(source, target)
+    if (OperatingSystem.current().isWindows) {
+        FileUtils.copyDirectory(source, target)
+    } else {
+        Files.createSymbolicLink(target.toPath(), source.toPath())
+    }
 }
 installGitHooks()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
+import org.apache.commons.io.FileUtils
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
-import java.nio.file.Files
 
 plugins {
     kotlin("plugin.serialization") apply false
@@ -39,6 +39,6 @@ fun installGitHooks() {
     val source = File(project.rootProject.rootDir, ".git-hooks")
     if (target.canonicalFile == source) return
     target.deleteRecursively()
-    Files.createSymbolicLink(target.toPath(), source.toPath())
+    FileUtils.copyDirectory(source, target)
 }
 installGitHooks()


### PR DESCRIPTION
On Windows symlinking directories requires elevated permission.