### PR TITLE
chore: ignore kotlin binary compatability validation files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,9 @@ sorapointa-core/langs/
 sorapointa-dispatch/langs/
 **/config/
 
-
 ### Database ###
 **/*.db
 *.db-journal
+
+## Kotlin binary compatibility validator
+*.api


### PR DESCRIPTION
These are auto generated and shouldn't be checked into vcs.